### PR TITLE
CODETOOLS-7902793: Fix IllegalMonitorStateException in JInternalFrameOperatorCloseTest

### DIFF
--- a/src/org/netbeans/jemmy/operators/Operator.java
+++ b/src/org/netbeans/jemmy/operators/Operator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -734,14 +734,22 @@ public abstract class Operator
      * defined by {@code "ComponentOperator.WaitStateTimeout"}
      */
     public void waitStateOnQueue(final ComponentChooser state) {
-        waitState((comp) -> {
-            return (boolean) (queueTool.invokeSmoothly(
-                    new QueueTool.QueueAction<Object>("checkComponent") {
-                @Override
-                public final Object launch() throws Exception {
-                    return state.checkComponent(comp);
-                }
-            }));
+        waitState(new ComponentChooser() {
+            @Override
+            public boolean checkComponent(Component comp) {
+                return (boolean) (queueTool.invokeSmoothly(
+                        new QueueTool.QueueAction<Object>("checkComponent") {
+                            @Override
+                            public final Object launch() throws Exception {
+                                return state.checkComponent(comp);
+                            }
+                        }));
+            }
+
+            @Override
+            public String getDescription() {
+                return state.getDescription();
+            }
         });
     }
 

--- a/src/org/netbeans/jemmy/version_info
+++ b/src/org/netbeans/jemmy/version_info
@@ -1,6 +1,6 @@
 Manifest-version: 1.0
 Main-Class: org.netbeans.jemmy.JemmyProperties
 Jemmy-MajorVersion: 3.0
-Jemmy-MinorVersion: 9.0
+Jemmy-MinorVersion: 10.0
 Jemmy-Build: @BUILD_NUMBER@
 

--- a/test/org/netbeans/jemmy/operators/JInternalFrameOperatorCloseTest.java
+++ b/test/org/netbeans/jemmy/operators/JInternalFrameOperatorCloseTest.java
@@ -92,10 +92,6 @@ public class JInternalFrameOperatorCloseTest {
                     ste.getMethodName().equals("waitClosed")));
             System.out.println("This exception has been caught, as expected:");
             e.printStackTrace(System.out);
-        } finally {
-            // Really closing the frame this time
-            internalFrame.done = true;
-            internalFrameOper.close();
         }
     }
 


### PR DESCRIPTION
What worked was to override setClosed(boolean) in JInternalFrame to not close the frame.

Also while inspecting the stack trace, I have discovered that the description is not passed down from JInternalFrameOperator.waitClosed()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Referenced JBS issue must only be used for a single change
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902793](https://bugs.openjdk.java.net/browse/CODETOOLS-7902793): Fix IllegalMonitorStateException in JInternalFrameOperatorCloseTest


### Reviewers
 * [Abdul Kolarkunnu](https://openjdk.java.net/census#akolarkunnu) (@akolarkunnu - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jemmy-v2 pull/4/head:pull/4`
`$ git checkout pull/4`
